### PR TITLE
/event-check-in subcommands to check in using email and discord id

### DIFF
--- a/src/api/events.ts
+++ b/src/api/events.ts
@@ -145,7 +145,7 @@ router.post("/guilds/:gid/events/:id/attendees", async (ctx) => {
   }
 });
 
-enum AttendeeQueryTypeEnum {
+export enum AttendeeQueryTypeEnum {
   DISCORD_ID = 'discordId',
   EMAIL = 'email'
 }

--- a/src/commands/events/attendingEvent.ts
+++ b/src/commands/events/attendingEvent.ts
@@ -9,14 +9,29 @@ dotenv.config();
 
 const GUILD_ID = process.env.GUILD_ID;
 
+export enum AttendingEventSubcommands {
+  DISCORD_ID = 'discord-id',
+  EMAIL = 'email'
+};
+
 const data = new SlashCommandBuilder()
   .setName("event-check-in")
   .setDescription("Checking for a Launch Pad event")
-  .addStringOption((option) =>
-    option
-      .setName("email")
-      .setDescription("The email you used to RSVP to the event")
-      .setRequired(true),
+  .addSubcommand(subcommand =>
+		subcommand
+      .setName(AttendingEventSubcommands.DISCORD_ID)
+      .setDescription("Check-in using your Discord ID")
+  )
+	.addSubcommand(subcommand =>
+		subcommand
+      .setName(AttendingEventSubcommands.EMAIL)
+      .setDescription("Check-in using your email")
+      .addStringOption((option) =>
+        option
+          .setName("email")
+          .setDescription("The email you used to RSVP to the event")
+          .setRequired(true)
+      )
   );
 
 async function execute(interaction) {
@@ -58,6 +73,7 @@ async function execute(interaction) {
           JSON.stringify({
             eventId: event.id,
             email: interaction.options.getString("email"),
+            discordId: interaction.member.user.id,
           }),
         ),
     );

--- a/src/util/github.ts
+++ b/src/util/github.ts
@@ -90,7 +90,7 @@ export async function initiateDeviceFlow() {
 
 export async function connectToGitHub(repoUrl: string, channelId: string, eventType: string) {
   const octokit = await app.getInstallationOctokit(LP_REPO_ID);
-  
+
   const [owner, repo] = extractOwnerAndRepo(repoUrl);
 
   // check existing webhook or not, if no, create one
@@ -149,7 +149,7 @@ export async function connectToGitHub(repoUrl: string, channelId: string, eventT
           }
         }
       };
-      
+
       // Convert to DB record
       const dbRecord = marshall(record);
 
@@ -176,7 +176,7 @@ export async function connectToGitHub(repoUrl: string, channelId: string, eventT
               }
             }
           };
-          
+
           // Convert to DB record
           const dbRecord = marshall(record);
 
@@ -252,7 +252,7 @@ export async function connectToGitHub(repoUrl: string, channelId: string, eventT
               }
             }
           };
-          
+
           // Convert to DB record
           const dbRecord = marshall(record);
 


### PR DESCRIPTION
Changes `/event-check-in` into `/event-check-in email` and `/event-check-in discord-id`. 
![image](https://github.com/ubclaunchpad/Colony/assets/69666141/06958b35-0784-4083-8d17-78a22c3831ee)

`/event-check-in email` has the same functionality as the old `/event-check-in` (i.e. check in to an event using email and get an event-attendee role if check-in is successful)

`/event-check-in discord-id` is the same as `/event-check-in email` but rather than asking for the user's email, it will grab the user's discord id automatically before confirming if there is an attendee with said discord id in the specified event

